### PR TITLE
allow form parameters and missing body is a string

### DIFF
--- a/lib/expressroutes.js
+++ b/lib/expressroutes.js
@@ -31,12 +31,34 @@ function expressroutes(router, options) {
             validate = validator.validate;
 
             before.push(function validateInput(req, res, next) {
-                var value, isPath, isForm, textBody;
+                var value, isPath;
 
                 isPath = parameter.paramType === 'path' || parameter.paramType === 'query';
-                isForm = parameter.paramType === 'form';
-                textBody = req.body == {} ? '' : req.body;
-                value = isPath ? req.param(parameter.name) : (isForm ?  req.body[parameter.name] : textBody);
+
+                switch (parameter.paramType) {
+                    case 'path':
+                    case 'query':
+                        value = req.param(parameter.name);
+                        break;
+                    case 'header':
+                        value = req.header(parameter.name);
+                        break;
+                    case 'body':
+                        value = req.body;
+                        //If the type is string and we found an empty object, convert to empty string.
+                        //This is a bug in express's body-parser: https://github.com/expressjs/body-parser/issues/44
+                        if (parameter.type === 'string') {
+                            if (thing.isObject(value) && !Object.keys(value).length) {
+                                value = '';
+                                break;
+                            }
+                            value = JSON.stringify(value);
+                        }
+                        break;
+                    case 'form':
+                        value = req.body[parameter.name];
+                        break;
+                }
 
                 validate(value, function (error, newvalue) {
                     if (error) {


### PR DESCRIPTION
see https://github.com/krakenjs/swaggerize-express/issues/18
- req.body defaults to {} when no body is present. Results in 'invalid type'. A {} is now converted to '' (empty string)
- parameter types not a path or query where all mapped to req.body. In case of form, it now reads from the body object (eg when using `app.use(bodyParser.urlencoded({ extended: true }))`)
