### PR TITLE
Change validation error message to include dataPath and subErrors

### DIFF
--- a/bin/lib/swaggerize.js
+++ b/bin/lib/swaggerize.js
@@ -33,10 +33,10 @@ module.exports = function (options) {
     validation = schema.validate(api);
 
     if (!validation.valid) {
-        console.error('%s: %s', validation.error.dataPath, validation.error);
+        console.error('%s (at %s)', validation.error, validation.error.dataPath);
         if (validation.error.subErrors) {
             validation.error.subErrors.forEach(function (subError) {
-                console.error('%s: %s', subError.dataPath, subError);
+                console.error('%s (at %s)', subError, subError.dataPath);
             });
         }
         return 1;


### PR DESCRIPTION
Validation errors are not expressive and doesn't print the subErrors.  

Currently validation errors show:

```
$ ./node_modules/.bin/swaggerize --api config/api.json --handlers resources/handlers --models resources/models --tests tests
Data does not match any schemas from "oneOf"
```

This adds additional context (dataPath) and prints subErrors:

```
 ./node_modules/.bin/swaggerize --api config/api.json --handlers resources/handlers --models resources/models --tests tests
/models/Item/properties/tags/items: ValidationError: Data does not match any schemas from "oneOf"
/models/Item/properties/tags/items: ValidationError: Missing required property: $ref
/models/Item/properties/tags/items/description: ValidationError: Additional properties not allowed
```
