### PR TITLE
Do not JSON.stringify a plain string (otherwise gets extra quotes)

### DIFF
--- a/lib/expressroutes.js
+++ b/lib/expressroutes.js
@@ -53,12 +53,8 @@ function expressroutes(router, options) {
                                 break;
                             }
                             //Coerce to a string since that's the type we expect and Express magic's it for us.
-                            if (!thing.isString(value)) {
+                            if (thing.isObject(value)) {
                                 req.body = value = JSON.stringify(value);
-                            }
-                        } else {
-                            if (thing.isString(value)) {
-                                req.body = value = JSON.parse(value);
                             }
                         }
 


### PR DESCRIPTION
when doing a `curl -d "x" <url> <etc>` for a 

```
        parameters:
          - name: body
            required: true
            type: string
            paramType: body
```

it becomes `'"x"'` (gets quoted) instead of just `'x'`.
Fix will do the JSON stringify only if the `req.body` is not yet a string
