### PR TITLE
Update deprecated express usage with new methods

### DIFF
--- a/lib/expressroutes.js
+++ b/lib/expressroutes.js
@@ -39,13 +39,13 @@ function expressroutes(router, options) {
                 var value, isPath;
 
                 switch (parameter.in) {
-                    case 'path':
+                    case 'path':                 
                     case 'query':
                         isPath = true;
-                        value = req.param(parameter.name);
+                        value = req.params[parameter.name]; 
                         break;
                     case 'header':
-                        value = req.header(parameter.name);
+                        value = req.get(parameter.name);
                         break;
                     case 'body':
                     case 'form':

--- a/test/fixtures/handlers/pets/{id}.js
+++ b/test/fixtures/handlers/pets/{id}.js
@@ -5,10 +5,10 @@ var store = require('../../lib/store');
 
 module.exports = {
     get: function (req, res) {
-        res.json(store.get(req.param('id')));
+        res.json(store.get(req.params['id']));
     },
     delete: function (req, res) {
-        store.delete(req.param('id'));
+        store.delete(req.params['id']);
         res.json(store.all());
     }
 };

--- a/test/test-swaggerize.js
+++ b/test/test-swaggerize.js
@@ -117,7 +117,7 @@ test('input validation', function (t) {
                     res.json({
                         id: 0,
                         name: 'Cat',
-                        tags: req.param('tags')
+                        tags: req.query.tags.split(',')
                     });
                 },
                 $post: function (req, res) {


### PR DESCRIPTION
Fix for https://github.com/krakenjs/swaggerize-express/issues/44

Replaces calls to 

`req.param()` with `req.params[]` or `req.query[]`

and `req.header()` with `req.get()`.