### PR TITLE
Use .yaml schema doc for yaml support tests.

### DIFF
--- a/test/test-swaggerize.js
+++ b/test/test-swaggerize.js
@@ -156,7 +156,7 @@ test('yaml support', function (t) {
 
         t.doesNotThrow(function () {
             app.use(swaggerize({
-                api: path.join(__dirname, './fixtures/defs/pets.json'),
+                api: path.join(__dirname, './fixtures/defs/pets.yaml'),
                 handlers: path.join(__dirname, 'fixtures/handlers')
             }));
         });


### PR DESCRIPTION
Quick fix for https://github.com/krakenjs/swaggerize-express/issues/50