### PR TITLE
Replace body with validated version

### DIFF
--- a/lib/expressroutes.js
+++ b/lib/expressroutes.js
@@ -36,7 +36,7 @@ function expressroutes(router, options) {
             validate = validator.validate;
 
             before.push(function validateInput(req, res, next) {
-                var value, isPath;
+                var value, isPath, isBody;
 
                 switch (parameter.in) {
                     case 'path':                 
@@ -49,6 +49,7 @@ function expressroutes(router, options) {
                         break;
                     case 'body':
                     case 'formData':
+                        isBody = true;
                         value = req.body;
                 }
 
@@ -61,6 +62,10 @@ function expressroutes(router, options) {
 
                     if (isPath) {
                         req.params[parameter.name] = newvalue;
+                    }
+
+                    if (isBody) {
+                        req.body = newvalue;
                     }
 
                     next();

--- a/test/test-swaggerize.js
+++ b/test/test-swaggerize.js
@@ -101,7 +101,7 @@ test('input validation', function (t) {
 
     app.use(bodyParser.json());
 
-    app.use(swaggerize({
+    var options = {
         api: require('./fixtures/defs/pets.json'),
         handlers: {
             'pets': {
@@ -121,11 +121,13 @@ test('input validation', function (t) {
                     });
                 },
                 $post: function (req, res) {
-                    res.send(typeof req.body);
+                    res.send(req.body);
                 }
             }
         }
-    }));
+    };
+
+    app.use(swaggerize(options));
 
     t.test('good query', function (t) {
         t.plan(3);
@@ -146,6 +148,28 @@ test('input validation', function (t) {
         });
     });
 
+    t.test('replace body with validated version', function(t) {
+        t.plan(5);
+
+        options.routes.forEach(function(route) {
+            route.validators.forEach(function(validator) {
+                if(!validator.schema) { return; }
+
+                validator.schema._settings = {
+                    allowUnknown: true,
+                    stripUnknown: true
+                };
+            });
+        });
+
+        request(app).post('/v1/petstore/pets').send({id: 0, name: 'fluffy', extra: ''}).end(function (error, response) {
+            t.ok(!error, 'no error.');
+            t.strictEqual(response.statusCode, 200, '200 status.');
+            t.ok(response.body.id === 0, 'id should exist and be zero');
+            t.ok(response.body.name === 'fluffy', 'name should exist and equal "fluffy"');
+            t.ok(!response.body.extra, 'extra parameters are ignored and stripped')
+        });
+    });
 });
 
 test('yaml support', function (t) {


### PR DESCRIPTION
Related to: krakenjs/swaggerize-builder#28

After validation, the body may have changed.

For example, when using the enjoi settings:

    allowUnknown: true
    stripUnknown: true

Properties may be removed from the incoming request body.  This change
ensures the newly validated body is used instead of the original.

(Cleaned up version of krakenjs/swaggerize-express/pull#46)