### PR TITLE
Rendering engine globably disabled by swaggerize-express

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,10 +56,7 @@ function mount(app, options) {
             "json replacer": null,
             "json spaces": 0,
             "case sensitive routing": false,
-            "strict routing": false,
-            "views": null,
-            "view cache": false,
-            "view engine": false
+            "strict routing": false
         }).forEach(function (name) {
             parent.set(name, settings[name]);
         });


### PR DESCRIPTION
Rendering engine is globally disabled by swaggerize-express, making it impossible to use express.render.