### PR TITLE
bugfix(routes): Handle file upload in formData

### DIFF
--- a/lib/expressroutes.js
+++ b/lib/expressroutes.js
@@ -52,6 +52,19 @@ function valueAccessor(param, consumes) {
     if (param.in === 'formData') {
         return {
             get: function(req, key) {
+                if (!thing.isNullOrUndefined(req.file) &&
+                    param.type === 'file' &&
+                    !thing.isNullOrUndefined(req.file.fieldname) &&
+                    req.file.fieldname === key) {
+
+                    if (req.file.buffer) {
+                        // when using InMemory option you get back a raw Buffer
+                        // convert to binary string so that validator does not fail
+                        // based on type.
+                        return req.file.buffer.toString('binary');
+                    }
+                    return req.file.path;
+                }
                 return req.body[key];
             },
             set: function(req, key, val) {

--- a/lib/expressroutes.js
+++ b/lib/expressroutes.js
@@ -52,18 +52,18 @@ function valueAccessor(param, consumes) {
     if (param.in === 'formData') {
         return {
             get: function(req, key) {
-                if (!thing.isNullOrUndefined(req.file) &&
-                    param.type === 'file' &&
-                    !thing.isNullOrUndefined(req.file.fieldname) &&
-                    req.file.fieldname === key) {
+                var file = req.file || Array.isArray(req.files) && req.files[0];
+                if (param.type === 'file' &&
+                    !thing.isNullOrUndefined(file.fieldname) &&
+                    file.fieldname === key) {
 
-                    if (req.file.buffer) {
+                    if (file.buffer) {
                         // when using InMemory option you get back a raw Buffer
                         // convert to binary string so that validator does not fail
                         // based on type.
-                        return req.file.buffer.toString('binary');
+                        return file.buffer.toString('binary');
                     }
-                    return req.file.path;
+                    return file.path;
                 }
                 return req.body[key];
             },

--- a/test/fixtures/defs/pets.json
+++ b/test/fixtures/defs/pets.json
@@ -26,7 +26,9 @@
     "paths": {
         "/upload": {
             "post": {
-                "consumes": "multipart/form-data",
+                "consumes": [
+                    "multipart/form-data"
+                ],
                 "operationId": "uploadFile",
                 "description": "uploads a file",
                 "parameters": [


### PR DESCRIPTION
The vauleAccessor for formData assumed that the attribute would always
be in the body but all of the multipart parsers for file uploads result
in the vaules being stored in `req.file` attribute.

Test `form data` will fail currently until krakenjs/swaggerize-routes#55
has been merged in as well.

Related to: krakenjs/swaggerize-routes#54
