### PR TITLE
add hooks to remove view configuration settings made on parent express application

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,9 +308,9 @@ Example:
 ```
 
 var Swaggerize = require('swaggerize-express');
-delete Swaggerize.expressOptions['views'];
-delete Swaggerize.expressOptions['view cache'];
-delete Swaggerize.expressOptions['view engine'];
+delete Swaggerize.defaultExpressOptions['views'];
+delete Swaggerize.defaultExpressOptions['view cache'];
+delete Swaggerize.defaultExpressOptions['view engine'];
 
 ... the bulk of your other server stuff goes here ...
 

--- a/README.md
+++ b/README.md
@@ -283,3 +283,43 @@ function authorize(req, res, next) {
     //...
 }
 ```
+
+### Running alongside a node development webserver
+
+For production, it is recommended to run the API separate from the
+webserver.  And as such, this middleware assumes that it is the only
+thing running inside the express app.
+
+However, if you would like to run your API alongside a webserver as a
+convenience during development, it is possible.  In this scenario, you
+will want to do two things:
+
+1. Remove the express parent app view configuration from the settings
+that are configured on the parent app during mount.  A convenience
+function `expressParentAppRemoveViewSettings` is already prepared to
+do exactly this.  This will allow any other template rendering system
+you may have already configured intact.
+
+2. Stand up the API server relatively late in your `server.js`.  This
+will give this middleware a fair chance at being the last thing that
+configures required settings on the parent express application.
+
+Example:
+
+```
+
+... the bulk of your other server stuff goes here ...
+
+// API ======================================================================
+var Swaggerize = require('swaggerize-express');
+Swaggerize.expressParentAppRemoveViewSettings(); // convenience function to remove view configuration settings.
+
+app.use(Swaggerize({
+    api: path.resolve('./<API_NAME>/config/swagger.json'),
+    handlers: path.resolve('./<API_NAME>/handlers')
+}));
+
+// launch ===================================================================
+app.listen(port);
+console.log('The magic happens on port ' + port);
+```

--- a/README.md
+++ b/README.md
@@ -295,10 +295,9 @@ convenience during development, it is possible.  In this scenario, you
 will want to do two things:
 
 1. Remove the express parent app view configuration from the settings
-that are configured on the parent app during mount.  A convenience
-function `expressParentAppRemoveViewSettings` is already prepared to
-do exactly this.  This will allow any other template rendering system
-you may have already configured intact.
+that are configured on the parent app during mount.  This will allow
+any other template rendering system you may have already configured
+intact.
 
 2. Stand up the API server relatively late in your `server.js`.  This
 will give this middleware a fair chance at being the last thing that
@@ -308,12 +307,14 @@ Example:
 
 ```
 
+var Swaggerize = require('swaggerize-express');
+delete Swaggerize.expressOptions['views'];
+delete Swaggerize.expressOptions['view cache'];
+delete Swaggerize.expressOptions['view engine'];
+
 ... the bulk of your other server stuff goes here ...
 
-// API ======================================================================
-var Swaggerize = require('swaggerize-express');
-Swaggerize.expressParentAppRemoveViewSettings(); // convenience function to remove view configuration settings.
-
+// Stand up API =============================================================
 app.use(Swaggerize({
     api: path.resolve('./<API_NAME>/config/swagger.json'),
     handlers: path.resolve('./<API_NAME>/handlers')

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,26 +44,13 @@ function swaggerize(options) {
 function mount(app, options) {
 
     return function onmount(parent) {
-        var settings;
-
         parent._router.stack.pop();
 
         //If a mountpath was provided, override basePath in api.
         options.api.basePath = app.mountpath !== '/' ? app.mountpath : options.api.basePath;
 
-        Object.keys(settings = {
-            'x-powered-by': false,
-            'trust proxy': false,
-            'jsonp callback name': null,
-            'json replacer': null,
-            'json spaces': 0,
-            'case sensitive routing': false,
-            'strict routing': false,
-            'views': null,
-            'view cache': false,
-            'view engine': false
-        }).forEach(function (option) {
-            parent.set(option, settings[option]);
+        Object.keys(swaggerize.expressParentAppSettings).forEach(function (option) {
+            parent.set(option, swaggerize.expressParentAppSettings[option]);
         });
 
         Object.keys(options.express).forEach(function (option) {
@@ -81,6 +68,25 @@ function mount(app, options) {
 
         expressroutes(parent._router, options);
     };
+}
+
+swaggerize.expressParentAppSettings = {
+            'x-powered-by': false,
+            'trust proxy': false,
+            'jsonp callback name': null,
+            'json replacer': null,
+            'json spaces': 0,
+            'case sensitive routing': false,
+            'strict routing': false,
+            'views': null,
+            'view cache': false,
+            'view engine': false
+        };
+
+swaggerize.expressParentAppRemoveViewSettings = function() {
+    delete swaggerize.expressParentAppSettings['views'];
+    delete swaggerize.expressParentAppSettings['view cache'];
+    delete swaggerize.expressParentAppSettings['view engine'];
 }
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,8 +49,8 @@ function mount(app, options) {
         //If a mountpath was provided, override basePath in api.
         options.api.basePath = app.mountpath !== '/' ? app.mountpath : options.api.basePath;
 
-        Object.keys(swaggerize.expressParentAppSettings).forEach(function (option) {
-            parent.set(option, swaggerize.expressParentAppSettings[option]);
+        Object.keys(swaggerize.expressOptions).forEach(function (option) {
+            parent.set(option, swaggerize.expressOptions[option]);
         });
 
         Object.keys(options.express).forEach(function (option) {
@@ -70,7 +70,7 @@ function mount(app, options) {
     };
 }
 
-swaggerize.expressParentAppSettings = {
+swaggerize.expressOptions = {
             'x-powered-by': false,
             'trust proxy': false,
             'jsonp callback name': null,
@@ -82,12 +82,6 @@ swaggerize.expressParentAppSettings = {
             'view cache': false,
             'view engine': false
         };
-
-swaggerize.expressParentAppRemoveViewSettings = function() {
-    delete swaggerize.expressParentAppSettings['views'];
-    delete swaggerize.expressParentAppSettings['view cache'];
-    delete swaggerize.expressParentAppSettings['view engine'];
-}
 
 /**
  * Loads the api from a path, with support for yaml..

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,12 +49,17 @@ function mount(app, options) {
         //If a mountpath was provided, override basePath in api.
         options.api.basePath = app.mountpath !== '/' ? app.mountpath : options.api.basePath;
 
-        Object.keys(swaggerize.expressOptions).forEach(function (option) {
-            parent.set(option, swaggerize.expressOptions[option]);
+        var expressOptions = {};
+        Object.keys(swaggerize.defaultExpressOptions).forEach(function (option) {
+            expressOptions[option] = swaggerize.defaultExpressOptions[option];
         });
 
         Object.keys(options.express).forEach(function (option) {
-            parent.set(option, options.express[option]);
+            expressOptions[option] = options.express[option];
+        });
+
+        Object.keys(expressOptions).forEach(function (option) {
+            parent.set(option, expressOptions[option]);
         });
 
         parent.mountpath = options.api.basePath;
@@ -70,7 +75,7 @@ function mount(app, options) {
     };
 }
 
-swaggerize.expressOptions = {
+swaggerize.defaultExpressOptions = {
             'x-powered-by': false,
             'trust proxy': false,
             'jsonp callback name': null,


### PR DESCRIPTION
I had to prevent swaggerize-express from configuring `views`, `view cache`, `view engine` on the express app in order to get the API to work in the same express app as our webserver.  We only plan on running this way for development.  What was happening is our template engine settings would get overwritten and then express couldn't serve our `handlebars` templates.

What I didn't know is is why those settings were placed there in the first place.  I assumed it was to deliberately disable any view stuff based on the assumption the API runs all by itself within express.  And that these are important settings.  I relied on those assumptions when adding to the README.  If I'm off base, I'd be willing to take a second pass at this.