### PR TITLE
update regex in "bleb" unit test.

### DIFF
--- a/test/test-expressroutes.js
+++ b/test/test-expressroutes.js
@@ -31,7 +31,7 @@ test('express routes', function (t) {
             t.strictEqual(stack.length, 3, '3 routes added.');
             t.strictEqual(stack[0].route.path, '/v1/petstore/api-docs', 'api-docs added.');
             t.strictEqual(stack[1].route.path, '/v1/petstore/pets/:id', 'hello added.');
-            t.strictEqual(stack[2].regexp.toString(), '/^\\/v1\\/petstore\\/pets\\/([^\\/]+?)(?:\\/(?=$))?$/i', 'bleb');
+            t.strictEqual(stack[2].regexp.toString(), '/^\\/v1\\/petstore\\/pets\\/((?:[^\\/]+?))(?:\\/(?=$))?$/i', 'bleb');
         });
 
         app.use(child);


### PR DESCRIPTION
I believe this is a safe modification because the regexes are equivalent.  The difference amounts to adding `(?: ... )` which inserts a non matching group.  I verified (by hand) that in chrome v8 inserting a non matching group inside a matching group does not affect the matching group.  The outer group still matches.
