### PR TITLE
remove view related express settings.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -58,10 +58,7 @@ function mount(app, options) {
             'json replacer': null,
             'json spaces': 0,
             'case sensitive routing': false,
-            'strict routing': false,
-            'views': null,
-            'view cache': false,
-            'view engine': false
+            'strict routing': false
         }).forEach(function (option) {
             parent.set(option, settings[option]);
         });


### PR DESCRIPTION
Simply removing these three options from the defaults allows my preferred view engine, handlebars, to work alongside swaggerize-express.  I'm not sure how important these settings are in general though...