### PR TITLE
[master] Create error when method is not allowed

### DIFF
--- a/lib/expressroutes.js
+++ b/lib/expressroutes.js
@@ -165,9 +165,13 @@ function buildNotAllowedMiddleware(methods) {
     return function (req, res, next) {
         if (methods.indexOf(req.method.toLowerCase()) === -1) {
             res.set('Allow', methods.join(', ').toUpperCase());
-            res.sendStatus(405).end();
+            const err = new Error('Method Not Allowed');
+
+            err.status = 405
+            next(err);
+        } else {
+            next();
         }
-        next();
     };
 }
 


### PR DESCRIPTION
It is useful when user has a middleware error handler, fix #144 