### PR TITLE
[v5.x] break middleware chain

### DIFF
--- a/lib/expressroutes.js
+++ b/lib/expressroutes.js
@@ -62,7 +62,7 @@ const makeExpressRoute = (router, mountpath, route, securityDefinitions) => {
 const buildNotAllowedMiddleware = methods => (req, res, next) => {
     if (methods.indexOf(req.method.toLowerCase()) === -1) {
         res.set('Allow', methods.join(', ').toUpperCase());
-        res.sendStatus(405).end();
+        return res.sendStatus(405).end();
     }
     next();
 };


### PR DESCRIPTION
break middleware chain, given the response has been sent, it will prevent ERR_HTTP_HEADERS_SENT, fix #144